### PR TITLE
Add SimpleCov test coverage configuration, closes openpprn/opn#56.

### DIFF
--- a/.simplecov
+++ b/.simplecov
@@ -1,0 +1,3 @@
+SimpleCov.start 'rails' do
+  add_filter '/app/mailers/mail_preview.rb'
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,3 +1,5 @@
+require 'simplecov'
+
 ENV["RAILS_ENV"] ||= "test"
 require File.expand_path("../../config/environment", __FILE__)
 require "rails/test_help"


### PR DESCRIPTION
This enables SimpleCov to create a `coverage/index.html` file for Rails projects.

cc @seanahrens 
